### PR TITLE
Create inseec-edu

### DIFF
--- a/lib/domains/com/inseec-edu
+++ b/lib/domains/com/inseec-edu
@@ -1,0 +1,1 @@
+Institut des hautes études économiques et commerciales


### PR DESCRIPTION
Added domain for ECE which is now part of the INSEEC.
Email domains for some teachers now use `inseec-edu.com` domain.
URL of page showing connection between ECE and INSEEC: http://www.ece.fr/ecole-ingenieur/ece-paris/reseaux/
URL of a page on the official website where an IT-related: http://www.ece.fr/school-of-engineering/program/7-specializations-majors/